### PR TITLE
Added optional maskLength support for PII censoring - Issue #2

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,55 +41,55 @@ env.backends.onnx.wasm.wasmPaths = path.join(__dirname, 'wasm/');
  * Ensures that the NER model is loaded only once.
  */
 export class NerPipelineSingleton {
-    static task = 'token-classification';
-    static model = 'Xenova/bert-base-NER';
-    static instance = null;
+  static task = 'token-classification';
+  static model = 'Xenova/bert-base-NER';
+  static instance = null;
 
-    /**
-     * Retrieves the singleton instance of the NER pipeline.
-     * @param {function} [progress_callback=null] - Optional callback function for progress updates during model loading.
-     * @returns {Promise<object>} A promise that resolves to the NER pipeline instance.
-     */
-    static async getInstance(progress_callback = null) {
-        if (this.instance === null) {
-            try {
-                // Create a new pipeline instance
-                this.instance = await pipeline(this.task, this.model, { progress_callback });
-            } catch (error) {
-                console.error('Error loading NER model or pipeline:', error);
-                console.error(
-                    "Please ensure model files are in 'models/Xenova/bert-base-NER/onnx/' and WASM files are in 'wasm/'.",
-                );
-                throw new Error(
-                    'Failed to initialize NER pipeline. Check model and WASM file paths.',
-                );
-            }
-        }
-        return this.instance;
+  /**
+   * Retrieves the singleton instance of the NER pipeline.
+   * @param {function} [progress_callback=null] - Optional callback function for progress updates during model loading.
+   * @returns {Promise<object>} A promise that resolves to the NER pipeline instance.
+   */
+  static async getInstance(progress_callback = null) {
+    if (this.instance === null) {
+      try {
+        // Create a new pipeline instance
+        this.instance = await pipeline(this.task, this.model, { progress_callback });
+      } catch (error) {
+        console.error('Error loading NER model or pipeline:', error);
+        console.error(
+          "Please ensure model files are in 'models/Xenova/bert-base-NER/onnx/' and WASM files are in 'wasm/'.",
+        );
+        throw new Error(
+          'Failed to initialize NER pipeline. Check model and WASM file paths.',
+        );
+      }
     }
+    return this.instance;
+  }
 }
 
 // --- Regex Patterns for Structured PII ---
 const regexPIIPatterns = [
-    { type: 'SSN', pattern: /\b\d{3}[- ]?\d{2}[- ]?\d{4}\b/g },
-    { type: 'CREDIT_CARD', pattern: /\b(?:\d[ -]*?){13,16}\b/g }, // Basic pattern, not validating prefixes or Luhn
-    {
-        type: 'CREDIT_CARD_EXPIRATION',
-        pattern:
-            /\b(?:Exp(?:ires|iration Date)?:?|Valid Thru:?)\s*(0[1-9]|1[0-2])[-/]([0-9]{2}|[0-9]{4})\b/g,
-    }, // MM/YY or MM/YYYY with mandatory prefixes
-    { type: 'EMAIL', pattern: /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g },
-    { type: 'PHONE', pattern: /\b(?:\(?\d{3}\)?[-. ]?\d{3}[-. ]?\d{4})\b/g }, // Common US formats
-    {
-        type: 'IP_ADDRESS',
-        pattern:
-            /\b(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b/g,
-    },
-    { type: 'VIN', pattern: /\b[A-HJ-NPR-Z0-9]{17}\b/g }, // Standard 17-character VIN, excluding I, O, Q
-    { type: 'ID_NUMBER', pattern: /\b\d{9}\b/g }, // General 9-digit ID (e.g., some driver's licenses, state IDs)
-    { type: 'PASSPORT_NUMBER', pattern: /\b[A-Z0-9]{8,12}\b/g }, // General 8-12 alphanumeric for passports
-    { type: 'MEDICAL_RECORD_NUMBER', pattern: /\bMRN-\d{7}\b/g }, // Specific to MRN-XXXXXXX format
-    { type: 'POLICY_NUMBER', pattern: /\b\d{5,10}\b/g }, // General 5-10 digit policy numbers
+  { type: 'SSN', pattern: /\b\d{3}[- ]?\d{2}[- ]?\d{4}\b/g },
+  { type: 'CREDIT_CARD', pattern: /\b(?:\d[ -]*?){13,16}\b/g }, // Basic pattern, not validating prefixes or Luhn
+  {
+    type: 'CREDIT_CARD_EXPIRATION',
+    pattern:
+      /\b(?:Exp(?:ires|iration Date)?:?|Valid Thru:?)\s*(0[1-9]|1[0-2])[-/]([0-9]{2}|[0-9]{4})\b/g,
+  }, // MM/YY or MM/YYYY with mandatory prefixes
+  { type: 'EMAIL', pattern: /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g },
+  { type: 'PHONE', pattern: /\b(?:\(?\d{3}\)?[-. ]?\d{3}[-. ]?\d{4})\b/g }, // Common US formats
+  {
+    type: 'IP_ADDRESS',
+    pattern:
+      /\b(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b/g,
+  },
+  { type: 'VIN', pattern: /\b[A-HJ-NPR-Z0-9]{17}\b/g }, // Standard 17-character VIN, excluding I, O, Q
+  { type: 'ID_NUMBER', pattern: /\b\d{9}\b/g }, // General 9-digit ID (e.g., some driver's licenses, state IDs)
+  { type: 'PASSPORT_NUMBER', pattern: /\b[A-Z0-9]{8,12}\b/g }, // General 8-12 alphanumeric for passports
+  { type: 'MEDICAL_RECORD_NUMBER', pattern: /\bMRN-\d{7}\b/g }, // Specific to MRN-XXXXXXX format
+  { type: 'POLICY_NUMBER', pattern: /\b\d{5,10}\b/g }, // General 5-10 digit policy numbers
 ];
 
 /**
@@ -99,165 +99,224 @@ const regexPIIPatterns = [
  * with Regular Expressions (Regex) for structured PII (SSN, credit cards, emails, phones, etc.).
  *
  * @param {string} input The string to censor.
+ * @param {Object} [options] Optional configuration object.
+ * @param {Object} [options] Optional configuration object.
+ * @param {string} [options.maskChar='*'] A single character used to mask each censored character.
  * @returns {Promise<string>} A promise that resolves to the censored string.
  */
-export async function censorPII(input) {
-    let ner;
-    try {
-        ner = await NerPipelineSingleton.getInstance();
-    } catch (error) {
-        console.error(
-            'PII censoring failed due to NER pipeline initialization error.',
-            error.message,
-        );
-        return input; // Graceful degradation: return original input on critical error
-    }
+export async function censorPII(input, options) {
+  const maskChar = isMaskCharValid(options?.maskChar) ? options.maskChar : undefined;
+  let ner;
+  try {
+    ner = await NerPipelineSingleton.getInstance();
+  } catch (error) {
+    console.error(
+      'PII censoring failed due to NER pipeline initialization error.',
+      error.message,
+    );
+    return input; // Graceful degradation: return original input on critical error
+  }
 
-    // 1. Get entities from NER model
-    let rawEntities = [];
-    try {
-        rawEntities = await ner(input, {
-            aggregation_strategy: 'none', // Get individual tokens
-        });
-    } catch (error) {
-        console.warn(
-            'Warning: NER model execution failed. Proceeding with regex only.',
-            error.message,
-        );
-        // Continue without NER entities if model execution fails
-    }
+  // 1. Get entities from NER model
+  let rawEntities = [];
+  try {
+    rawEntities = await ner(input, {
+      aggregation_strategy: 'none', // Get individual tokens
+    });
+  } catch (error) {
+    console.warn(
+      'Warning: NER model execution failed. Proceeding with regex only.',
+      error.message,
+    );
+    // Continue without NER entities if model execution fails
+  }
 
-    let aggregatedEntities = [];
-    let currentEntity = null;
-    let currentInputIndex = 0; // Track current position in the input string
+  let aggregatedEntities = [];
+  let currentEntity = null;
+  let currentInputIndex = 0; // Track current position in the input string
 
-    for (const entity of rawEntities) {
-        const entityType = entity.entity.split('-').pop(); // e.g., PER, ORG, LOC, MISC, DATE
-        const entityTag = entity.entity.split('-')[0]; // e.g., B, I, O
+  for (const entity of rawEntities) {
+    const entityType = entity.entity.split('-').pop(); // e.g., PER, ORG, LOC, MISC, DATE
+    const entityTag = entity.entity.split('-')[0]; // e.g., B, I, O
 
-        if (entityTag === 'B') {
-            // Start of a new entity
-            if (currentEntity !== null) {
-                aggregatedEntities.push(currentEntity);
-            }
-
-            // Find the start index of the new entity's word in the remaining input string
-            const wordToFind = entity.word.startsWith('##')
-                ? entity.word.substring(2)
-                : entity.word;
-            const startIndex = input.indexOf(wordToFind, currentInputIndex);
-
-            if (startIndex !== -1) {
-                currentEntity = {
-                    entity_group: entityType,
-                    word: wordToFind,
-                    start: startIndex,
-                    end: startIndex + wordToFind.length,
-                    score: entity.score,
-                };
-                currentInputIndex = startIndex + wordToFind.length;
-            } else {
-                // If word not found, treat as non-entity or skip
-                currentEntity = null;
-            }
-        } else if (
-            entityTag === 'I' &&
-            currentEntity !== null &&
-            currentEntity.entity_group === entityType
-        ) {
-            // Continuation of the current entity
-            const wordToAppend = entity.word.startsWith('##')
-                ? entity.word.substring(2)
-                : ' ' + entity.word;
-            const startIndex = input.indexOf(wordToAppend, currentInputIndex);
-
-            if (startIndex !== -1) {
-                currentEntity.word += wordToAppend;
-                currentEntity.end = startIndex + wordToAppend.length;
-                currentEntity.score = Math.min(currentEntity.score, entity.score); // Take min score for aggregated entity
-                currentInputIndex = startIndex + wordToAppend.length;
-            } else {
-                // If continuation word not found, finalize current entity and reset
-                aggregatedEntities.push(currentEntity);
-                currentEntity = null;
-            }
-        } else {
-            // Not a B- or I- tag, or a new entity type without a B-tag, or 'O' (Outside)
-            if (currentEntity !== null) {
-                aggregatedEntities.push(currentEntity);
-            }
-            currentEntity = null; // Reset
-            // Advance currentInputIndex past the current word
-            const wordToAdvance = entity.word.startsWith('##')
-                ? entity.word.substring(2)
-                : entity.word;
-            const nextIndex = input.indexOf(wordToAdvance, currentInputIndex);
-            if (nextIndex !== -1) {
-                currentInputIndex = nextIndex + wordToAdvance.length;
-            } else {
-                currentInputIndex++; // Fallback if word not found
-            }
-        }
-    }
-
-    // Push the last entity if it exists
-    if (currentEntity !== null) {
+    if (entityTag === 'B') {
+      // Start of a new entity
+      if (currentEntity !== null) {
         aggregatedEntities.push(currentEntity);
+      }
+
+      // Find the start index of the new entity's word in the remaining input string
+      const wordToFind = entity.word.startsWith('##')
+        ? entity.word.substring(2)
+        : entity.word;
+      const startIndex = input.indexOf(wordToFind, currentInputIndex);
+
+      if (startIndex !== -1) {
+        currentEntity = {
+          entity_group: entityType,
+          word: wordToFind,
+          start: startIndex,
+          end: startIndex + wordToFind.length,
+          score: entity.score,
+        };
+        currentInputIndex = startIndex + wordToFind.length;
+      } else {
+        // If word not found, treat as non-entity or skip
+        currentEntity = null;
+      }
+    } else if (
+      entityTag === 'I' &&
+      currentEntity !== null &&
+      currentEntity.entity_group === entityType
+    ) {
+      // Continuation of the current entity
+      const wordToAppend = entity.word.startsWith('##')
+        ? entity.word.substring(2)
+        : ' ' + entity.word;
+      const startIndex = input.indexOf(wordToAppend, currentInputIndex);
+
+      if (startIndex !== -1) {
+        currentEntity.word += wordToAppend;
+        currentEntity.end = startIndex + wordToAppend.length;
+        currentEntity.score = Math.min(currentEntity.score, entity.score); // Take min score for aggregated entity
+        currentInputIndex = startIndex + wordToAppend.length;
+      } else {
+        // If continuation word not found, finalize current entity and reset
+        aggregatedEntities.push(currentEntity);
+        currentEntity = null;
+      }
+    } else {
+      // Not a B- or I- tag, or a new entity type without a B-tag, or 'O' (Outside)
+      if (currentEntity !== null) {
+        aggregatedEntities.push(currentEntity);
+      }
+      currentEntity = null; // Reset
+      // Advance currentInputIndex past the current word
+      const wordToAdvance = entity.word.startsWith('##')
+        ? entity.word.substring(2)
+        : entity.word;
+      const nextIndex = input.indexOf(wordToAdvance, currentInputIndex);
+      if (nextIndex !== -1) {
+        currentInputIndex = nextIndex + wordToAdvance.length;
+      } else {
+        currentInputIndex++; // Fallback if word not found
+      }
     }
+  }
 
-    // 2. Get entities from Regex patterns
-    let regexEntities = [];
-    for (const { type, pattern } of regexPIIPatterns) {
-        let match;
-        while ((match = pattern.exec(input)) !== null) {
-            regexEntities.push({
-                entity_group: type,
-                word: match[0],
-                start: match.index,
-                end: match.index + match[0].length,
-                score: 1.0, // Assign a high score for regex matches
-            });
-        }
+  // Push the last entity if it exists
+  if (currentEntity !== null) {
+    aggregatedEntities.push(currentEntity);
+  }
+
+  // 2. Get entities from Regex patterns
+  let regexEntities = [];
+  for (const { type, pattern } of regexPIIPatterns) {
+    let match;
+    while ((match = pattern.exec(input)) !== null) {
+      regexEntities.push({
+        entity_group: type,
+        word: match[0],
+        start: match.index,
+        end: match.index + match[0].length,
+        score: 1.0, // Assign a high score for regex matches
+      });
     }
+  }
 
-    // 3. Combine and filter all PII entities
-    // Filter for NER PII types + all regex types
-    const allPiiEntities = aggregatedEntities
-        .filter(
-            (entity) =>
-                entity.entity_group === 'PER' || // Person
-                entity.entity_group === 'ORG' || // Organization
-                entity.entity_group === 'LOC' || // Location
-                entity.entity_group === 'MISC', // Miscellaneous can sometimes catch other PII
-            // DATE is excluded as the model doesn't reliably detect it
-        )
-        .concat(regexEntities);
+  // 3. Combine and filter all PII entities
+  // Filter for NER PII types + all regex types
+  const allPiiEntities = aggregatedEntities
+    .filter(
+      (entity) =>
+        entity.entity_group === 'PER' || // Person
+        entity.entity_group === 'ORG' || // Organization
+        entity.entity_group === 'LOC' || // Location
+        entity.entity_group === 'MISC', // Miscellaneous can sometimes catch other PII
+      // DATE is excluded as the model doesn't reliably detect it
+    )
+    .concat(regexEntities);
 
-    // Sort all entities by their starting index in descending order.
-    // This is crucial to avoid messing up indices as we replace text.
-    allPiiEntities.sort((a, b) => b.start - a.start);
+  // Sort all entities by their starting index in descending order.
+  // This is crucial to avoid messing up indices as we replace text.
+  allPiiEntities.sort((a, b) => b.start - a.start);
 
-    let censoredText = input;
+  let censoredText = input;
 
-    // Replace each detected PII entity with [CENSORED]
-    for (const entity of allPiiEntities) {
-        // Ensure valid start and end indices
-        if (
-            typeof entity.start === 'number' &&
-            typeof entity.end === 'number' &&
-            entity.start !== -1 &&
-            entity.end !== -1 &&
-            entity.start < entity.end
-        ) {
-            const replacement = '[CENSORED]';
-            censoredText =
-                censoredText.substring(0, entity.start) +
-                replacement +
-                censoredText.substring(entity.end);
-        } else {
-            console.warn(`Invalid entity indices received for entity: ${JSON.stringify(entity)}`);
-        }
+  // Replace each detected PII entity with [CENSORED]
+  for (const entity of allPiiEntities) {
+    if (isValidEntity(entity)) {
+      const replacement = maskSubstring(entity.end - entity.start, maskChar)
+      censoredText =
+        censoredText.substring(0, entity.start) +
+        replacement +
+        censoredText.substring(entity.end);
+    } else {
+      console.warn(`Invalid entity indices received for entity: ${JSON.stringify(entity)}`);
     }
+  }
 
-    return censoredText;
+  return censoredText;
+}
+
+/**
+ * Checks whether an entity object has valid start and end indices for text replacement.
+ *
+ * An entity is considered valid if:
+ * - `start` and `end` are numbers
+ * - `start` is greater than or equal to 0
+ * - `end` is greater than `start`
+ *
+ * @param {{ start: number, end: number }} entity The entity object containing start and end indices.
+ * @returns {boolean} `true` if the entity indices are valid, otherwise `false`.
+ */
+function isValidEntity(entity) {
+  return (
+    typeof entity.start === 'number' &&
+    typeof entity.end === 'number' &&
+    entity.start >= 0 &&
+    entity.end > entity.start
+  );
+}
+
+/**
+ * Generates a masking string of a given length using the specified character.
+ *
+ * @param {number} length The number of times to repeat the mask character.
+ * @param {string} [maskChar] Optional single-character mask.
+ * @returns {string} A string consisting of the mask character repeated `length` times.
+ */
+function maskSubstring(length, maskChar) {
+  if (maskChar) {
+    return maskChar.repeat(length);
+  }
+  return '[CENSORED]';
+}
+
+
+/**
+ * Checks whether a given string is a valid mask character.
+ *
+ * A valid mask character must:
+ *   1. Be a string of length 1 (Unicode grapheme-safe).
+ *   2. Be a visible character (not whitespace).
+ *   3. Not be a control character (Unicode category C).
+ *
+ * Examples of valid mask characters: '*', '#', 'X', '✓'.
+ * Examples of invalid mask characters: '', ' ', '\n', '\u0000'.
+ *
+ * @param {string} maskChar - The character to validate.
+ * @returns {boolean} True if maskChar is a single, visible, non-control character; false otherwise.
+ */
+function isMaskCharValid(maskChar) {
+  if (typeof maskChar !== 'string') return false;
+
+  const chars = [...maskChar]; // Unicode-safe splitting
+  if (chars.length !== 1) return false;
+
+  const c = chars[0];
+  if (c.trim() === '') return false;        // No whitespace
+  if (/\p{C}/u.test(c)) return false;      // No control chars
+
+  return true;
 }

--- a/test/edge-cases.test.js
+++ b/test/edge-cases.test.js
@@ -2,150 +2,202 @@ import { jest } from '@jest/globals';
 import { setupTestEnvironment } from './setup.js';
 
 describe('Edge Cases and Integration Tests', () => {
-    let censorPII;
+  let censorPII;
 
-    beforeAll(async () => {
-        const setup = await setupTestEnvironment();
-        censorPII = setup.censorPII;
+  beforeAll(async () => {
+    const setup = await setupTestEnvironment();
+    censorPII = setup.censorPII;
+  });
+
+  describe('Empty and Whitespace Inputs', () => {
+    test.each([
+      ['', undefined, ''],
+      ['', '*', ''],
+    ])('should handle empty string (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
     });
 
-    describe('Empty and Whitespace Inputs', () => {
-        test('should handle empty string', async () => {
-            const original = '';
-            const expected = '';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
-
-        test('should handle string with only spaces', async () => {
-            const original = '   ';
-            const expected = '   ';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
-
-        test('should handle string with only tabs and newlines', async () => {
-            const original = '\t\n\r';
-            const expected = '\t\n\r';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
+    test.each([
+      ['   ', undefined, '   '],
+      ['   ', '*', '   '],
+    ])('should handle string with only spaces (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
     });
 
-    describe('Non-PII Text', () => {
-        test('should not censor non-PII text', async () => {
-            const original = 'This is a regular sentence with no sensitive information.';
-            const expected = 'This is a regular sentence with no sensitive information.';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
+    test.each([
+      ['\t\n\r', undefined, '\t\n\r'],
+      ['\t\n\r', '*', '\t\n\r'],
+    ])('should handle string with only tabs and newlines (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
+    });
+  });
 
-        test('should not censor numbers that are not PII', async () => {
-            const original = 'The temperature is 72 degrees.';
-            const expected = 'The temperature is 72 degrees.';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
-
-        test('should not censor dates that are not credit card expirations', async () => {
-            const original = 'Date of birth: 01/01/1990.';
-            const expected = 'Date of birth: 01/01/1990.';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
+  describe('Non-PII Text', () => {
+    test.each([
+      ['This is a regular sentence with no sensitive information.', undefined,
+        'This is a regular sentence with no sensitive information.'],
+      ['This is a regular sentence with no sensitive information.', '*',
+        'This is a regular sentence with no sensitive information.'],
+    ])('should not censor non-PII text (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
     });
 
-    describe('Overlapping PII Detection', () => {
-        test('should handle overlapping PII correctly (longer match first)', async () => {
-            const original = 'My email is test@example.com and my name is John Doe.';
-            const expected = 'My email is [CENSORED] and my name is [CENSORED].';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
-
-        test('should handle multiple occurrences of the same PII type', async () => {
-            const original = 'John Doe and Jane Smith are here.';
-            const expected = '[CENSORED] and Jane Smith are here.';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
-
-        test('should handle PII with different spacing in numbers', async () => {
-            const original = 'SSN: 123 45 6789 and Phone: (123)456-7890.';
-            const expected = '[CENSORED]: [CENSORED] and Phone: ([CENSORED].';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
+    test.each([
+      ['The temperature is 72 degrees.', undefined, 'The temperature is 72 degrees.'],
+      ['The temperature is 72 degrees.', '*', 'The temperature is 72 degrees.'],
+    ])('should not censor numbers that are not PII (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
     });
 
-    describe('Boundary Conditions', () => {
-        test('should handle PII at the beginning of the string', async () => {
-            const original = 'John Doe is here.';
-            const expected = '[CENSORED] is here.';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
+    test.each([
+      ['Date of birth: 01/01/1990.', undefined, 'Date of birth: 01/01/1990.'],
+      ['Date of birth: 01/01/1990.', '*', 'Date of birth: 01/01/1990.'],
+    ])('should not censor dates that are not credit card expirations (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
+    });
+  });
 
-        test('should handle PII at the end of the string', async () => {
-            const original = 'Here is John Doe.';
-            const expected = 'Here is [CENSORED].';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
-
-        test('should handle PII as the entire string', async () => {
-            const original = 'John Doe';
-            const expected = '[CENSORED]';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
-
-        test('should handle PII with punctuation', async () => {
-            const original = 'Hello, John Doe! How are you?';
-            const expected = 'Hello, [CENSORED]! How are you?';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
+  describe('Overlapping PII Detection', () => {
+    test.each([
+      ['My email is test@example.com and my name is John Doe.', undefined,
+        'My email is [CENSORED] and my name is [CENSORED].'],
+      ['My email is test@example.com and my name is John Doe.', '*',
+        'My email is **************** and my name is ********.'],
+    ])('should handle overlapping PII correctly (longer match first) (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
     });
 
-    describe('Complex Integration Scenarios', () => {
-        test('should handle multiple PII types in one string', async () => {
-            const original = 'John Doe (SSN: 123-45-6789) lives at 123 Oak Ave, Anytown, NY. Email: john.doe@mail.com. Phone: (555) 123-4567.';
-            const expected = '[CENSORED] (SSN: [CENSORED]) lives at 123 Oak Ave, Anytown, NY. Email: [CENSORED]. Phone: ([CENSORED].';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
-
-        test('should handle very long strings with multiple PII', async () => {
-            const original = 'This is a very long string that contains multiple pieces of PII including John Doe who works at Acme Corp and lives in New York. His email is john.doe@example.com and his phone is (555) 123-4567. He also has an SSN of 123-45-6789.';
-            const expected = 'This is a very long string that contains multiple pieces of PII including [CENSORED] who works at Acme Corp and lives in New York. His email is [CENSORED] and his phone is ([CENSORED]. He also has an SSN of [CENSORED].';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
-
-        test('should handle strings with special characters and PII', async () => {
-            const original = 'User: John Doe\nEmail: test@example.com\nPhone: (555) 123-4567\nSSN: 123-45-6789';
-            const expected = 'User: [CENSORED]\nEmail: [CENSORED]\nPhone: ([CENSORED]\nSSN: [CENSORED]';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
+    test.each([
+      ['John Doe and Jane Smith are here.', undefined, '[CENSORED] and Jane Smith are here.'],
+      ['John Doe and Jane Smith are here.', '*', '******** and Jane Smith are here.'],
+    ])('should handle multiple occurrences of the same PII type (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
     });
 
-    describe('Error Handling', () => {
-        test('should handle malformed input gracefully', async () => {
-            const original = null;
-            // The implementation handles null gracefully by returning the input
-            await expect(censorPII(original)).resolves.toBe(original);
-        });
+    test.each([
+      ['SSN: 123 45 6789 and Phone: (123)456-7890.', undefined,
+        '[CENSORED]: [CENSORED] and Phone: ([CENSORED].'],
+      ['SSN: 123 45 6789 and Phone: (123)456-7890.', '*',
+        '***: *********** and Phone: (************.'],
+    ])('should handle PII with different spacing in numbers (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
+    });
+  });
 
-        test('should handle undefined input gracefully', async () => {
-            const original = undefined;
-            // The implementation handles undefined gracefully by returning the input
-            await expect(censorPII(original)).resolves.toBe(original);
-        });
-
-        test('should handle non-string input gracefully', async () => {
-            const original = 123;
-            // The implementation handles non-string input gracefully by returning the input
-            await expect(censorPII(original)).resolves.toBe(original);
-        });
+  describe('Boundary Conditions', () => {
+    test.each([
+      ['John Doe is here.', undefined, '[CENSORED] is here.'],
+      ['John Doe is here.', '*', '******** is here.'],
+    ])('should handle PII at the beginning of the string (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
     });
 
-    describe('Performance Edge Cases', () => {
-        test('should handle strings with many potential PII patterns', async () => {
-            const original = '123-45-6789 987-65-4321 555-12-3456 111-22-3333 444-55-6666';
-            const expected = '[CENSORED]ED]SORED][CENSORED]ED]';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
-
-        test('should handle strings with repeated patterns', async () => {
-            const original = 'test@example.com test@example.com test@example.com';
-            const expected = '[CENSORED] [CENSORED] [CENSORED]';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
+    test.each([
+      ['Here is John Doe.', undefined, 'Here is [CENSORED].'],
+      ['Here is John Doe.', '*', 'Here is ********.'],
+    ])('should handle PII at the end of the string (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
     });
+
+    test.each([
+      ['John Doe', undefined, '[CENSORED]'],
+      ['John Doe', '*', '********'],
+    ])('should handle PII as the entire string (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
+    });
+
+    test.each([
+      ['Hello, John Doe! How are you?', undefined, 'Hello, [CENSORED]! How are you?'],
+      ['Hello, John Doe! How are you?', '*', 'Hello, ********! How are you?'],
+    ])('should handle PII with punctuation (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
+    });
+  });
+
+  describe('Complex Integration Scenarios', () => {
+    test.each([
+      ['John Doe (SSN: 123-45-6789) lives at 123 Oak Ave, Anytown, NY. Email: john.doe@mail.com. Phone: (555) 123-4567.', undefined,
+        '[CENSORED] (SSN: [CENSORED]) lives at 123 Oak Ave, Anytown, NY. Email: [CENSORED]. Phone: ([CENSORED].'],
+      ['John Doe (SSN: 123-45-6789) lives at 123 Oak Ave, Anytown, NY. Email: john.doe@mail.com. Phone: (555) 123-4567.', '*',
+        '******** (SSN: ***********) lives at 123 Oak Ave, Anytown, NY. Email: *****************. Phone: (*************.'],
+    ])('should handle multiple PII types in one string (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
+    });
+
+    test.each([
+      ['This is a very long string that contains multiple pieces of PII including John Doe who works at Acme Corp and lives in New York. His email is john.doe@example.com and his phone is (555) 123-4567. He also has an SSN of 123-45-6789.', undefined,
+        'This is a very long string that contains multiple pieces of PII including [CENSORED] who works at Acme Corp and lives in New York. His email is [CENSORED] and his phone is ([CENSORED]. He also has an SSN of [CENSORED].'],
+      ['This is a very long string that contains multiple pieces of PII including John Doe who works at Acme Corp and lives in New York. His email is john.doe@example.com and his phone is (555) 123-4567. He also has an SSN of 123-45-6789.', '*',
+        'This is a very long string that contains multiple pieces of PII including ******** who works at Acme Corp and lives in New York. His email is ******************** and his phone is (*************. He also has an SSN of ***********.'],
+    ])('should handle very long strings with multiple PII (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
+    });
+
+    test.each([
+      ['User: John Doe\nEmail: test@example.com\nPhone: (555) 123-4567\nSSN: 123-45-6789', undefined,
+        'User: [CENSORED]\nEmail: [CENSORED]\nPhone: ([CENSORED]\nSSN: [CENSORED]'],
+      ['User: John Doe\nEmail: test@example.com\nPhone: (555) 123-4567\nSSN: 123-45-6789', '*',
+        'User: ********\nEmail: ****************\nPhone: (*************\nSSN: ***********'],
+    ])('should handle strings with special characters and PII (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
+    });
+  });
+
+  describe('Error Handling', () => {
+    test('should handle malformed input gracefully', async () => {
+      const original = null;
+      // The implementation handles null gracefully by returning the input
+      await expect(censorPII(original)).resolves.toBe(original);
+    });
+
+    test('should handle undefined input gracefully', async () => {
+      const original = undefined;
+      // The implementation handles undefined gracefully by returning the input
+      await expect(censorPII(original)).resolves.toBe(original);
+    });
+
+    test('should handle non-string input gracefully', async () => {
+      const original = 123;
+      // The implementation handles non-string input gracefully by returning the input
+      await expect(censorPII(original)).resolves.toBe(original);
+    });
+  });
+
+  describe('Performance Edge Cases', () => {
+    test.each([
+      ['123-45-6789 987-65-4321 555-12-3456 111-22-3333 444-55-6666', undefined,
+        '[CENSORED]ED]SORED][CENSORED]ED]'],
+      ['123-45-6789 987-65-4321 555-12-3456 111-22-3333 444-55-6666', '*',
+        '*********************************** ***********************'],
+    ])('should handle strings with many potential PII patterns (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
+    });
+
+    test.each([
+      ['test@example.com test@example.com test@example.com', undefined,
+        '[CENSORED] [CENSORED] [CENSORED]'],
+      ['test@example.com test@example.com test@example.com', '*',
+        '**************** **************** ****************'],
+    ])('should handle strings with repeated patterns (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
+    });
+  });
+
+  describe('Invalid maskChar Handling', () => {
+    test.each([
+      [null],
+      [undefined],
+      [''],
+      ['  '],
+      ['\n'],
+      ['**'], // multiple characters
+      [123], // non-string
+      [{}],
+    ])('should fallback to default when maskChar is %p', async (invalidMaskChar) => {
+      const original = 'John Doe';
+      const expected = '[CENSORED]';
+
+      await expect(censorPII(original, { maskChar: invalidMaskChar })).resolves.toBe(expected);
+    });
+  });
 });

--- a/test/edge-cases.test.js
+++ b/test/edge-cases.test.js
@@ -11,136 +11,344 @@ describe('Edge Cases and Integration Tests', () => {
 
   describe('Empty and Whitespace Inputs', () => {
     test.each([
-      ['', undefined, ''],
-      ['', '*', ''],
-    ])('should handle empty string (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      ['', { maskChar: undefined }, ''],
+      ['', { maskChar: '*' }, ''],
+      ['', { maskChar: '*', maskLength: 5 }, ''],
+    ])(
+      'should handle empty string (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
 
     test.each([
-      ['   ', undefined, '   '],
-      ['   ', '*', '   '],
-    ])('should handle string with only spaces (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      ['   ', { maskChar: undefined }, '   '],
+      ['   ', { maskChar: '*' }, '   '],
+      ['   ', { maskChar: '*', maskLength: 5 }, '   '],
+    ])(
+      'should handle string with only spaces (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
 
     test.each([
-      ['\t\n\r', undefined, '\t\n\r'],
-      ['\t\n\r', '*', '\t\n\r'],
-    ])('should handle string with only tabs and newlines (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      ['\t\n\r', { maskChar: undefined }, '\t\n\r'],
+      ['\t\n\r', { maskChar: '*' }, '\t\n\r'],
+      ['\t\n\r', { maskChar: '*', maskLength: 5 }, '\t\n\r'],
+    ])(
+      'should handle string with only tabs and newlines (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
   });
 
   describe('Non-PII Text', () => {
     test.each([
-      ['This is a regular sentence with no sensitive information.', undefined,
-        'This is a regular sentence with no sensitive information.'],
-      ['This is a regular sentence with no sensitive information.', '*',
-        'This is a regular sentence with no sensitive information.'],
-    ])('should not censor non-PII text (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      [
+        'This is a regular sentence with no sensitive information.',
+        { maskChar: undefined },
+        'This is a regular sentence with no sensitive information.',
+      ],
+      [
+        'This is a regular sentence with no sensitive information.',
+        { maskChar: '*' },
+        'This is a regular sentence with no sensitive information.',
+      ],
+      [
+        'This is a regular sentence with no sensitive information.',
+        { maskChar: '*', maskLength: 5 },
+        'This is a regular sentence with no sensitive information.',
+      ],
+    ])(
+      'should not censor non-PII text (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
 
     test.each([
-      ['The temperature is 72 degrees.', undefined, 'The temperature is 72 degrees.'],
-      ['The temperature is 72 degrees.', '*', 'The temperature is 72 degrees.'],
-    ])('should not censor numbers that are not PII (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      [
+        'The temperature is 72 degrees.',
+        { maskChar: undefined },
+        'The temperature is 72 degrees.',
+      ],
+      [
+        'The temperature is 72 degrees.',
+        { maskChar: '*' },
+        'The temperature is 72 degrees.',
+      ],
+      [
+        'The temperature is 72 degrees.',
+        { maskChar: '*', maskLength: 5 },
+        'The temperature is 72 degrees.',
+      ],
+    ])(
+      'should not censor numbers that are not PII (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
 
     test.each([
-      ['Date of birth: 01/01/1990.', undefined, 'Date of birth: 01/01/1990.'],
-      ['Date of birth: 01/01/1990.', '*', 'Date of birth: 01/01/1990.'],
-    ])('should not censor dates that are not credit card expirations (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      [
+        'Date of birth: 01/01/1990.',
+        { maskChar: undefined },
+        'Date of birth: 01/01/1990.',
+      ],
+      [
+        'Date of birth: 01/01/1990.',
+        { maskChar: '*' },
+        'Date of birth: 01/01/1990.',
+      ],
+      [
+        'Date of birth: 01/01/1990.',
+        { maskChar: '*', maskLength: 5 },
+        'Date of birth: 01/01/1990.',
+      ],
+    ])(
+      'should not censor dates that are not credit card expirations (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
   });
 
   describe('Overlapping PII Detection', () => {
     test.each([
-      ['My email is test@example.com and my name is John Doe.', undefined,
-        'My email is [CENSORED] and my name is [CENSORED].'],
-      ['My email is test@example.com and my name is John Doe.', '*',
-        'My email is **************** and my name is ********.'],
-    ])('should handle overlapping PII correctly (longer match first) (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      [
+        'My email is test@example.com and my name is John Doe.',
+        { maskChar: undefined },
+        'My email is [CENSORED] and my name is [CENSORED].',
+      ],
+      [
+        'My email is test@example.com and my name is John Doe.',
+        { maskChar: '*' },
+        'My email is **************** and my name is ********.',
+      ],
+      [
+        'My email is test@example.com and my name is John Doe.',
+        { maskChar: '*', maskLength: 5 },
+        'My email is ***** and my name is *****.',
+      ],
+    ])(
+      'should handle overlapping PII correctly (longer match first) (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
 
     test.each([
-      ['John Doe and Jane Smith are here.', undefined, '[CENSORED] and Jane Smith are here.'],
-      ['John Doe and Jane Smith are here.', '*', '******** and Jane Smith are here.'],
-    ])('should handle multiple occurrences of the same PII type (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      [
+        'John Doe and Jane Smith are here.',
+        { maskChar: undefined },
+        '[CENSORED] and Jane Smith are here.',
+      ],
+      [
+        'John Doe and Jane Smith are here.',
+        { maskChar: '*' },
+        '******** and Jane Smith are here.',
+      ],
+      [
+        'John Doe and Jane Smith are here.',
+        { maskChar: '*', maskLength: 5 },
+        '***** and Jane Smith are here.',
+      ],
+    ])(
+      'should handle multiple occurrences of the same PII type (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
 
     test.each([
-      ['SSN: 123 45 6789 and Phone: (123)456-7890.', undefined,
-        '[CENSORED]: [CENSORED] and Phone: ([CENSORED].'],
-      ['SSN: 123 45 6789 and Phone: (123)456-7890.', '*',
-        '***: *********** and Phone: (************.'],
-    ])('should handle PII with different spacing in numbers (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      [
+        'SSN: 123 45 6789 and Phone: (123)456-7890.',
+        { maskChar: undefined },
+        '[CENSORED]: [CENSORED] and Phone: ([CENSORED].',
+      ],
+      [
+        'SSN: 123 45 6789 and Phone: (123)456-7890.',
+        { maskChar: '*' },
+        '***: *********** and Phone: (************.',
+      ],
+      [
+        'SSN: 123 45 6789 and Phone: (123)456-7890.',
+        { maskChar: '*', maskLength: 5 },
+        '*****: ***** and Phone: (*****.',
+      ],
+    ])(
+      'should handle PII with different spacing in numbers (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
   });
 
   describe('Boundary Conditions', () => {
     test.each([
-      ['John Doe is here.', undefined, '[CENSORED] is here.'],
-      ['John Doe is here.', '*', '******** is here.'],
-    ])('should handle PII at the beginning of the string (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      [
+        'John Doe is here.',
+        { maskChar: undefined },
+        '[CENSORED] is here.',
+      ],
+      [
+        'John Doe is here.',
+        { maskChar: '*' },
+        '******** is here.',
+      ],
+      [
+        'John Doe is here.',
+        { maskChar: '*', maskLength: 5 },
+        '***** is here.',
+      ],
+    ])(
+      'should handle PII at the beginning of the string (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
 
     test.each([
-      ['Here is John Doe.', undefined, 'Here is [CENSORED].'],
-      ['Here is John Doe.', '*', 'Here is ********.'],
-    ])('should handle PII at the end of the string (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      [
+        'Here is John Doe.',
+        { maskChar: undefined },
+        'Here is [CENSORED].',
+      ],
+      [
+        'Here is John Doe.',
+        { maskChar: '*' },
+        'Here is ********.',
+      ],
+      [
+        'Here is John Doe.',
+        { maskChar: '*', maskLength: 5 },
+        'Here is *****.',
+      ],
+    ])(
+      'should handle PII at the end of the string (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
 
     test.each([
-      ['John Doe', undefined, '[CENSORED]'],
-      ['John Doe', '*', '********'],
-    ])('should handle PII as the entire string (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      [
+        'John Doe',
+        { maskChar: undefined },
+        '[CENSORED]',
+      ],
+      [
+        'John Doe',
+        { maskChar: '*' },
+        '********',
+      ],
+      [
+        'John Doe',
+        { maskChar: '*', maskLength: 5 },
+        '*****',
+      ],
+    ])(
+      'should handle PII as the entire string (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
 
     test.each([
-      ['Hello, John Doe! How are you?', undefined, 'Hello, [CENSORED]! How are you?'],
-      ['Hello, John Doe! How are you?', '*', 'Hello, ********! How are you?'],
-    ])('should handle PII with punctuation (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      [
+        'Hello, John Doe! How are you?',
+        { maskChar: undefined },
+        'Hello, [CENSORED]! How are you?',
+      ],
+      [
+        'Hello, John Doe! How are you?',
+        { maskChar: '*' },
+        'Hello, ********! How are you?',
+      ],
+      [
+        'Hello, John Doe! How are you?',
+        { maskChar: '*', maskLength: 5 },
+        'Hello, *****! How are you?',
+      ],
+    ])(
+      'should handle PII with punctuation (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
   });
 
   describe('Complex Integration Scenarios', () => {
     test.each([
-      ['John Doe (SSN: 123-45-6789) lives at 123 Oak Ave, Anytown, NY. Email: john.doe@mail.com. Phone: (555) 123-4567.', undefined,
-        '[CENSORED] (SSN: [CENSORED]) lives at 123 Oak Ave, Anytown, NY. Email: [CENSORED]. Phone: ([CENSORED].'],
-      ['John Doe (SSN: 123-45-6789) lives at 123 Oak Ave, Anytown, NY. Email: john.doe@mail.com. Phone: (555) 123-4567.', '*',
-        '******** (SSN: ***********) lives at 123 Oak Ave, Anytown, NY. Email: *****************. Phone: (*************.'],
-    ])('should handle multiple PII types in one string (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      [
+        'John Doe (SSN: 123-45-6789) lives at 123 Oak Ave, Anytown, NY. Email: john.doe@mail.com. Phone: (555) 123-4567.',
+        { maskChar: undefined },
+        '[CENSORED] (SSN: [CENSORED]) lives at 123 Oak Ave, Anytown, NY. Email: [CENSORED]. Phone: ([CENSORED].',
+      ],
+      [
+        'John Doe (SSN: 123-45-6789) lives at 123 Oak Ave, Anytown, NY. Email: john.doe@mail.com. Phone: (555) 123-4567.',
+        { maskChar: '*' },
+        '******** (SSN: ***********) lives at 123 Oak Ave, Anytown, NY. Email: *****************. Phone: (*************.',
+      ],
+      [
+        'John Doe (SSN: 123-45-6789) lives at 123 Oak Ave, Anytown, NY. Email: john.doe@mail.com. Phone: (555) 123-4567.',
+        { maskChar: '*', maskLength: 5 },
+        '***** (SSN: *****) lives at 123 Oak Ave, Anytown, NY. Email: *****. Phone: (*****.',
+      ],
+    ])(
+      'should handle multiple PII types in one string (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
 
     test.each([
-      ['This is a very long string that contains multiple pieces of PII including John Doe who works at Acme Corp and lives in New York. His email is john.doe@example.com and his phone is (555) 123-4567. He also has an SSN of 123-45-6789.', undefined,
-        'This is a very long string that contains multiple pieces of PII including [CENSORED] who works at Acme Corp and lives in New York. His email is [CENSORED] and his phone is ([CENSORED]. He also has an SSN of [CENSORED].'],
-      ['This is a very long string that contains multiple pieces of PII including John Doe who works at Acme Corp and lives in New York. His email is john.doe@example.com and his phone is (555) 123-4567. He also has an SSN of 123-45-6789.', '*',
-        'This is a very long string that contains multiple pieces of PII including ******** who works at Acme Corp and lives in New York. His email is ******************** and his phone is (*************. He also has an SSN of ***********.'],
-    ])('should handle very long strings with multiple PII (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      [
+        'This is a very long string that contains multiple pieces of PII including John Doe who works at Acme Corp and lives in New York. His email is john.doe@example.com and his phone is (555) 123-4567. He also has an SSN of 123-45-6789.',
+        { maskChar: undefined },
+        'This is a very long string that contains multiple pieces of PII including [CENSORED] who works at Acme Corp and lives in New York. His email is [CENSORED] and his phone is ([CENSORED]. He also has an SSN of [CENSORED].',
+      ],
+      [
+        'This is a very long string that contains multiple pieces of PII including John Doe who works at Acme Corp and lives in New York. His email is john.doe@example.com and his phone is (555) 123-4567. He also has an SSN of 123-45-6789.',
+        { maskChar: '*' },
+        'This is a very long string that contains multiple pieces of PII including ******** who works at Acme Corp and lives in New York. His email is ******************** and his phone is (*************. He also has an SSN of ***********.',
+      ],
+      [
+        'This is a very long string that contains multiple pieces of PII including John Doe who works at Acme Corp and lives in New York. His email is john.doe@example.com and his phone is (555) 123-4567. He also has an SSN of 123-45-6789.',
+        { maskChar: '*', maskLength: 5 },
+        'This is a very long string that contains multiple pieces of PII including ***** who works at Acme Corp and lives in New York. His email is ***** and his phone is (*****. He also has an SSN of *****.',
+      ],
+    ])(
+      'should handle very long strings with multiple PII (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
 
     test.each([
-      ['User: John Doe\nEmail: test@example.com\nPhone: (555) 123-4567\nSSN: 123-45-6789', undefined,
-        'User: [CENSORED]\nEmail: [CENSORED]\nPhone: ([CENSORED]\nSSN: [CENSORED]'],
-      ['User: John Doe\nEmail: test@example.com\nPhone: (555) 123-4567\nSSN: 123-45-6789', '*',
-        'User: ********\nEmail: ****************\nPhone: (*************\nSSN: ***********'],
-    ])('should handle strings with special characters and PII (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      [
+        'User: John Doe\nEmail: test@example.com\nPhone: (555) 123-4567\nSSN: 123-45-6789',
+        { maskChar: undefined },
+        'User: [CENSORED]\nEmail: [CENSORED]\nPhone: ([CENSORED]\nSSN: [CENSORED]',
+      ],
+      [
+        'User: John Doe\nEmail: test@example.com\nPhone: (555) 123-4567\nSSN: 123-45-6789',
+        { maskChar: '*' },
+        'User: ********\nEmail: ****************\nPhone: (*************\nSSN: ***********',
+      ],
+      [
+        'User: John Doe\nEmail: test@example.com\nPhone: (555) 123-4567\nSSN: 123-45-6789',
+        { maskChar: '*', maskLength: 5 },
+        'User: *****\nEmail: *****\nPhone: (*****\nSSN: *****',
+      ],
+    ])(
+      'should handle strings with special characters and PII (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
   });
 
   describe('Error Handling', () => {
@@ -165,22 +373,50 @@ describe('Edge Cases and Integration Tests', () => {
 
   describe('Performance Edge Cases', () => {
     test.each([
-      ['123-45-6789 987-65-4321 555-12-3456 111-22-3333 444-55-6666', undefined,
-        '[CENSORED]ED]SORED][CENSORED]ED]'],
-      ['123-45-6789 987-65-4321 555-12-3456 111-22-3333 444-55-6666', '*',
-        '*********************************** ***********************'],
-    ])('should handle strings with many potential PII patterns (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      [
+        '123-45-6789 987-65-4321 555-12-3456 111-22-3333 444-55-6666',
+        { maskChar: undefined },
+        '[CENSORED]RED]SORED] [CENSORED]RED]',
+      ],
+      [
+        '123-45-6789 987-65-4321 555-12-3456 111-22-3333 444-55-6666',
+        { maskChar: '*' },
+        '*********************************** ***********************',
+      ],
+      [
+        '123-45-6789 987-65-4321 555-12-3456 111-22-3333 444-55-6666',
+        { maskChar: '*', maskLength: 5 },
+        '***** *****',
+      ],
+    ])(
+      'should handle strings with many potential PII patterns (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
 
     test.each([
-      ['test@example.com test@example.com test@example.com', undefined,
-        '[CENSORED] [CENSORED] [CENSORED]'],
-      ['test@example.com test@example.com test@example.com', '*',
-        '**************** **************** ****************'],
-    ])('should handle strings with repeated patterns (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      [
+        'test@example.com test@example.com test@example.com',
+        { maskChar: undefined },
+        '[CENSORED] [CENSORED] [CENSORED]',
+      ],
+      [
+        'test@example.com test@example.com test@example.com',
+        { maskChar: '*' },
+        '**************** **************** ****************',
+      ],
+      [
+        'test@example.com test@example.com test@example.com',
+        { maskChar: '*', maskLength: 5 },
+        '***** ***** *****',
+      ],
+    ])(
+      'should handle strings with repeated patterns (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
   });
 
   describe('Invalid maskChar Handling', () => {

--- a/test/ner.test.js
+++ b/test/ner.test.js
@@ -11,106 +11,163 @@ describe('NER (Named Entity Recognition) Tests', () => {
 
   describe('Person (PER) Detection', () => {
     test.each([
-      ['My name is John Doe.', undefined, 'My name is [CENSORED].'],
-      ['My name is John Doe.', '*', 'My name is ********.'],
-    ])('should censor a full name (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
-
-    test('should censor multiple person names', async () => {
-      const original = 'John Doe and Jane Smith are here.';
-      const expected = '[CENSORED] and Jane Smith are here.';
-      await expect(censorPII(original)).resolves.toBe(expected);
-    });
+      ['My name is John Doe.', { maskChar: undefined }, 'My name is [CENSORED].'],
+      ['My name is John Doe.', { maskChar: '*' }, 'My name is ********.'],
+      ['My name is John Doe.', { maskChar: '*', maskLength: 5 }, 'My name is *****.'],
+    ])(
+      'should censor a full name (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
 
     test.each([
-      ['Alice Wonderland is a character.', undefined, '[CENSORED] is a character.'],
-      ['Alice Wonderland is a character.', '*', '**************** is a character.'],
-    ])('should censor complex person names (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      ['John Doe and Jane Smith are here.', { maskChar: undefined }, '[CENSORED] and Jane Smith are here.'],
+      ['John Doe and Jane Smith are here.', { maskChar: '*' }, '******** and Jane Smith are here.'],
+      ['John Doe and Jane Smith are here.', { maskChar: '*', maskLength: 5 }, '***** and Jane Smith are here.'],
+    ])(
+      'should censor multiple person names (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
 
     test.each([
-      ['Bob The Builder is here.', undefined, '[CENSORED] is here.'],
-      ['Bob The Builder is here.', '*', '*************** is here.'],
-    ])('should censor names with titles (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      ['Alice Wonderland is a character.', { maskChar: undefined }, '[CENSORED] is a character.'],
+      ['Alice Wonderland is a character.', { maskChar: '*' }, '**************** is a character.'],
+      ['Alice Wonderland is a character.', { maskChar: '*', maskLength: 5 }, '***** is a character.'],
+    ])(
+      'should censor complex person names (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
+
+    test.each([
+      ['Bob The Builder is here.', { maskChar: undefined }, '[CENSORED] is here.'],
+      ['Bob The Builder is here.', { maskChar: '*' }, '*************** is here.'],
+      ['Bob The Builder is here.', { maskChar: '*', maskLength: 5 }, '***** is here.'],
+    ])(
+      'should censor names with titles (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
   });
 
   describe('Organization (ORG) Detection', () => {
     test.each([
-      ['I work for Acme Corp.', undefined, 'I work for [CENSORED].'],
-      ['I work for Acme Corp.', '*', 'I work for *********.'],
-    ])('censors a simple organization name (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      ['I work for Acme Corp.', { maskChar: undefined }, 'I work for [CENSORED].'],
+      ['I work for Acme Corp.', { maskChar: '*' }, 'I work for *********.'],
+      ['I work for Acme Corp.', { maskChar: '*', maskLength: 5 }, 'I work for *****.'],
+    ])(
+      'censors a simple organization name (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
 
     test.each([
-      ['John Doe, CEO of Acme Inc., lives in New York.', undefined, '[CENSORED], CEO of Acme Inc., lives in New York.'],
-      ['John Doe, CEO of Acme Inc., lives in New York.', '*', '********, CEO of Acme Inc., lives in New York.'],
-    ])('censors organization names with abbreviations (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      ['John Doe, CEO of Acme Inc., lives in New York.', { maskChar: undefined }, '[CENSORED], CEO of Acme Inc., lives in New York.'],
+      ['John Doe, CEO of Acme Inc., lives in New York.', { maskChar: '*' }, '********, CEO of Acme Inc., lives in New York.'],
+      ['John Doe, CEO of Acme Inc., lives in New York.', { maskChar: '*', maskLength: 5 }, '*****, CEO of Acme Inc., lives in New York.'],
+    ])(
+      'censors organization names with abbreviations (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
 
     test.each([
-      ['Blue Cross Blue Shield is an insurance company.', undefined, '[CENSORED] is an insurance company.'],
-      ['Blue Cross Blue Shield is an insurance company.', '*', '********************** is an insurance company.'],
-    ])('censors complex organization names (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      ['Blue Cross Blue Shield is an insurance company.', { maskChar: undefined }, '[CENSORED] is an insurance company.'],
+      ['Blue Cross Blue Shield is an insurance company.', { maskChar: '*' }, '********************** is an insurance company.'],
+      ['Blue Cross Blue Shield is an insurance company.', { maskChar: '*', maskLength: 5 }, '***** is an insurance company.'],
+    ])(
+      'censors complex organization names (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
   });
 
   describe('Location (LOC) Detection', () => {
     test.each([
-      ['He lives in New York.', undefined, 'He lives in [CENSORED].'],
-      ['He lives in New York.', '*', 'He lives in ********.'],
-    ])('censors a location (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      ['He lives in New York.', { maskChar: undefined }, 'He lives in [CENSORED].'],
+      ['He lives in New York.', { maskChar: '*' }, 'He lives in ********.'],
+      ['He lives in New York.', { maskChar: '*', maskLength: 5 }, 'He lives in *****.'],
+    ])(
+      'censors a location (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
 
     test.each([
-      ['The address is 123 Oak Ave.', undefined, 'The address is 123 [CENSORED].'],
-      ['The address is 123 Oak Ave.', '*', 'The address is 123 *******.'],
-    ])('censors street addresses (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      ['The address is 123 Oak Ave.', { maskChar: undefined }, 'The address is 123 [CENSORED].'],
+      ['The address is 123 Oak Ave.', { maskChar: '*' }, 'The address is 123 *******.'],
+      ['The address is 123 Oak Ave.', { maskChar: '*', maskLength: 5 }, 'The address is 123 *****.'],
+    ])(
+      'censors street addresses (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
 
     test.each([
-      ['Anytown is a small city.', undefined, '[CENSORED] is a small city.'],
-      ['Anytown is a small city.', '*', '******* is a small city.'],
-    ])('censors city names (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      ['Anytown is a small city.', { maskChar: undefined }, '[CENSORED] is a small city.'],
+      ['Anytown is a small city.', { maskChar: '*' }, '******* is a small city.'],
+      ['Anytown is a small city.', { maskChar: '*', maskLength: 5 }, '***** is a small city.'],
+    ])(
+      'censors city names (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
 
     test.each([
-      ['He is from NY.', undefined, 'He is from [CENSORED].'],
-      ['He is from NY.', '*', 'He is from **.'],
-    ])('censors state abbreviations (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      ['He is from NY.', { maskChar: undefined }, 'He is from [CENSORED].'],
+      ['He is from NY.', { maskChar: '*' }, 'He is from **.'],
+      ['He is from NY.', { maskChar: '*', maskLength: 5 }, 'He is from *****.'],
+    ])(
+      'censors state abbreviations (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
   });
 
   describe('Mixed NER Entities', () => {
     test.each([
-      ['John Doe, CEO of Acme Inc., lives in New York.', undefined, '[CENSORED], CEO of Acme Inc., lives in New York.'],
-      ['John Doe, CEO of Acme Inc., lives in New York.', '*', '********, CEO of Acme Inc., lives in New York.'],
-    ])('should censor mixed NER entities (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      ['John Doe, CEO of Acme Inc., lives in New York.', { maskChar: undefined }, '[CENSORED], CEO of Acme Inc., lives in New York.'],
+      ['John Doe, CEO of Acme Inc., lives in New York.', { maskChar: '*' }, '********, CEO of Acme Inc., lives in New York.'],
+      ['John Doe, CEO of Acme Inc., lives in New York.', { maskChar: '*', maskLength: 5 }, '*****, CEO of Acme Inc., lives in New York.'],
+    ])(
+      'should censor mixed NER entities (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
 
     test.each([
-      ['John Doe is here.', undefined, '[CENSORED] is here.'],
-      ['John Doe is here.', '*', '******** is here.'],
-    ])('should handle PII at the beginning of the string (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      ['John Doe is here.', { maskChar: undefined }, '[CENSORED] is here.'],
+      ['John Doe is here.', { maskChar: '*' }, '******** is here.'],
+      ['John Doe is here.', { maskChar: '*', maskLength: 5 }, '***** is here.'],
+    ])(
+      'should handle PII at the beginning of the string (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
 
     test.each([
-      ['Here is John Doe.', undefined, 'Here is [CENSORED].'],
-      ['Here is John Doe.', '*', 'Here is ********.'],
-    ])('should handle PII at the end of the string (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      ['Here is John Doe.', { maskChar: undefined }, 'Here is [CENSORED].'],
+      ['Here is John Doe.', { maskChar: '*' }, 'Here is ********.'],
+      ['Here is John Doe.', { maskChar: '*', maskLength: 5 }, 'Here is *****.'],
+    ])(
+      'should handle PII at the end of the string (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
   });
 });

--- a/test/ner.test.js
+++ b/test/ner.test.js
@@ -2,102 +2,115 @@ import { jest } from '@jest/globals';
 import { setupTestEnvironment } from './setup.js';
 
 describe('NER (Named Entity Recognition) Tests', () => {
-    let censorPII;
+  let censorPII;
 
-    beforeAll(async () => {
-        const setup = await setupTestEnvironment();
-        censorPII = setup.censorPII;
+  beforeAll(async () => {
+    const setup = await setupTestEnvironment();
+    censorPII = setup.censorPII;
+  });
+
+  describe('Person (PER) Detection', () => {
+    test.each([
+      ['My name is John Doe.', undefined, 'My name is [CENSORED].'],
+      ['My name is John Doe.', '*', 'My name is ********.'],
+    ])('should censor a full name (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
     });
 
-    describe('Person (PER) Detection', () => {
-        test('should censor a full name', async () => {
-            const original = 'My name is John Doe.';
-            const expected = 'My name is [CENSORED].';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
-
-        test('should censor multiple person names', async () => {
-            const original = 'John Doe and Jane Smith are here.';
-            const expected = '[CENSORED] and Jane Smith are here.';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
-
-        test('should censor complex person names', async () => {
-            const original = 'Alice Wonderland is a character.';
-            const expected = '[CENSORED] is a character.';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
-
-        test('should censor names with titles', async () => {
-            const original = 'Bob The Builder is here.';
-            const expected = '[CENSORED] is here.';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
+    test('should censor multiple person names', async () => {
+      const original = 'John Doe and Jane Smith are here.';
+      const expected = '[CENSORED] and Jane Smith are here.';
+      await expect(censorPII(original)).resolves.toBe(expected);
     });
 
-    describe('Organization (ORG) Detection', () => {
-        test('should censor an organization name', async () => {
-            const original = 'I work for Acme Corp.';
-            const expected = 'I work for [CENSORED].';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
-
-        test('should censor organization names with abbreviations', async () => {
-            const original = 'John Doe, CEO of Acme Inc., lives in New York.';
-            const expected = '[CENSORED], CEO of Acme Inc., lives in New York.';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
-
-        test('should censor complex organization names', async () => {
-            const original = 'Blue Cross Blue Shield is an insurance company.';
-            const expected = '[CENSORED] is an insurance company.';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
+    test.each([
+      ['Alice Wonderland is a character.', undefined, '[CENSORED] is a character.'],
+      ['Alice Wonderland is a character.', '*', '**************** is a character.'],
+    ])('should censor complex person names (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
     });
 
-    describe('Location (LOC) Detection', () => {
-        test('should censor a location', async () => {
-            const original = 'He lives in New York.';
-            const expected = 'He lives in [CENSORED].';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
+    test.each([
+      ['Bob The Builder is here.', undefined, '[CENSORED] is here.'],
+      ['Bob The Builder is here.', '*', '*************** is here.'],
+    ])('should censor names with titles (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
+    });
+  });
 
-        test('should censor street addresses', async () => {
-            const original = 'The address is 123 Oak Ave.';
-            const expected = 'The address is 123 [CENSORED].';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
-
-        test('should censor city names', async () => {
-            const original = 'Anytown is a small city.';
-            const expected = '[CENSORED] is a small city.';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
-
-        test('should censor state abbreviations', async () => {
-            const original = 'He is from NY.';
-            const expected = 'He is from [CENSORED].';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
+  describe('Organization (ORG) Detection', () => {
+    test.each([
+      ['I work for Acme Corp.', undefined, 'I work for [CENSORED].'],
+      ['I work for Acme Corp.', '*', 'I work for *********.'],
+    ])('censors a simple organization name (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
     });
 
-    describe('Mixed NER Entities', () => {
-        test('should censor mixed NER entities', async () => {
-            const original = 'John Doe, CEO of Acme Inc., lives in New York.';
-            const expected = '[CENSORED], CEO of Acme Inc., lives in New York.';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
-
-        test('should handle PII at the beginning of the string', async () => {
-            const original = 'John Doe is here.';
-            const expected = '[CENSORED] is here.';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
-
-        test('should handle PII at the end of the string', async () => {
-            const original = 'Here is John Doe.';
-            const expected = 'Here is [CENSORED].';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
+    test.each([
+      ['John Doe, CEO of Acme Inc., lives in New York.', undefined, '[CENSORED], CEO of Acme Inc., lives in New York.'],
+      ['John Doe, CEO of Acme Inc., lives in New York.', '*', '********, CEO of Acme Inc., lives in New York.'],
+    ])('censors organization names with abbreviations (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
     });
+
+    test.each([
+      ['Blue Cross Blue Shield is an insurance company.', undefined, '[CENSORED] is an insurance company.'],
+      ['Blue Cross Blue Shield is an insurance company.', '*', '********************** is an insurance company.'],
+    ])('censors complex organization names (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
+    });
+  });
+
+  describe('Location (LOC) Detection', () => {
+    test.each([
+      ['He lives in New York.', undefined, 'He lives in [CENSORED].'],
+      ['He lives in New York.', '*', 'He lives in ********.'],
+    ])('censors a location (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
+    });
+
+    test.each([
+      ['The address is 123 Oak Ave.', undefined, 'The address is 123 [CENSORED].'],
+      ['The address is 123 Oak Ave.', '*', 'The address is 123 *******.'],
+    ])('censors street addresses (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
+    });
+
+    test.each([
+      ['Anytown is a small city.', undefined, '[CENSORED] is a small city.'],
+      ['Anytown is a small city.', '*', '******* is a small city.'],
+    ])('censors city names (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
+    });
+
+    test.each([
+      ['He is from NY.', undefined, 'He is from [CENSORED].'],
+      ['He is from NY.', '*', 'He is from **.'],
+    ])('censors state abbreviations (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
+    });
+  });
+
+  describe('Mixed NER Entities', () => {
+    test.each([
+      ['John Doe, CEO of Acme Inc., lives in New York.', undefined, '[CENSORED], CEO of Acme Inc., lives in New York.'],
+      ['John Doe, CEO of Acme Inc., lives in New York.', '*', '********, CEO of Acme Inc., lives in New York.'],
+    ])('should censor mixed NER entities (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
+    });
+
+    test.each([
+      ['John Doe is here.', undefined, '[CENSORED] is here.'],
+      ['John Doe is here.', '*', '******** is here.'],
+    ])('should handle PII at the beginning of the string (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
+    });
+
+    test.each([
+      ['Here is John Doe.', undefined, 'Here is [CENSORED].'],
+      ['Here is John Doe.', '*', 'Here is ********.'],
+    ])('should handle PII at the end of the string (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
+    });
+  });
 });

--- a/test/regex-pii.test.js
+++ b/test/regex-pii.test.js
@@ -2,152 +2,173 @@ import { jest } from '@jest/globals';
 import { setupTestEnvironment } from './setup.js';
 
 describe('Regex PII Detection Tests', () => {
-    let censorPII;
+  let censorPII;
 
-    beforeAll(async () => {
-        const setup = await setupTestEnvironment();
-        censorPII = setup.censorPII;
+  beforeAll(async () => {
+    const setup = await setupTestEnvironment();
+    censorPII = setup.censorPII;
+  });
+
+  describe('Social Security Number (SSN)', () => {
+    test.each([
+      ['My SSN is 123-45-6789.', undefined, 'My [CENSORED] is [CENSORED].'],
+      ['My SSN is 123-45-6789.', '*', 'My *** is ***********.'],
+    ])('censors a Social Security Number (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
     });
 
-    describe('Social Security Number (SSN)', () => {
-        test('should censor a Social Security Number (SSN)', async () => {
-            const original = 'My SSN is 123-45-6789.';
-            const expected = 'My [CENSORED] is [CENSORED].';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
-
-        test('should censor SSN with different spacing', async () => {
-            const original = 'SSN: 123 45 6789';
-            const expected = '[CENSORED]: [CENSORED]';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
-
-        test('should not censor partial SSN-like numbers without full pattern', async () => {
-            const original = 'My number is 123-45.';
-            const expected = 'My number is 123-45.';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
+    test.each([
+      ['SSN: 123 45 6789', undefined, '[CENSORED]: [CENSORED]'],
+      ['SSN: 123 45 6789', '*', '***: ***********'],
+    ])('censors SSN with different spacing (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
     });
 
-    describe('Email Addresses', () => {
-        test('should censor an email address', async () => {
-            const original = 'Contact me at test@example.com.';
-            const expected = 'Contact me at [CENSORED].';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
+    test.each([
+      ['My number is 123-45.', undefined, 'My number is 123-45.'],
+      ['My number is 123-45.', '*', 'My number is 123-45.'],
+    ])('does not censor partial SSN-like numbers without full pattern (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
+    });
+  });
 
-        test('should censor email with subdomain', async () => {
-            const original = 'Email: user@sub.example.com';
-            const expected = 'Email: [CENSORED]';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
+  describe('Email Addresses', () => {
+    test('should censor an email address', async () => {
+      const original = 'Contact me at test@example.com.';
+      const expected = 'Contact me at [CENSORED].';
+      await expect(censorPII(original)).resolves.toBe(expected);
     });
 
-    describe('Phone Numbers', () => {
-        test('should censor a phone number', async () => {
-            const original = 'Call me at (123) 456-7890.';
-            const expected = 'Call me at ([CENSORED].';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
+    test('should censor email with subdomain', async () => {
+      const original = 'Email: user@sub.example.com';
+      const expected = 'Email: [CENSORED]';
+      await expect(censorPII(original)).resolves.toBe(expected);
+    });
+  });
 
-        test('should censor phone with different formats', async () => {
-            const original = 'Phone: (123)456-7890.';
-            const expected = '[CENSORED]: ([CENSORED].';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
+  describe('Phone Numbers', () => {
+    test.each([
+      ['Call me at (123) 456-7890.', undefined, 'Call me at ([CENSORED].'],
+      ['Call me at (123) 456-7890.', '*', 'Call me at (*************.'],
+    ])('censors a phone number (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
     });
 
-    describe('IP Addresses', () => {
-        test('should censor an IP address', async () => {
-            const original = 'Server IP: 192.168.1.1.';
-            const expected = 'Server IP: [CENSORED].';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
+    test.each([
+      ['Phone: (123)456-7890.', undefined, '[CENSORED]: ([CENSORED].'],
+      ['Phone: (123)456-7890.', '*', '*****: (************.'],
+    ])('censors phone with different formats (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
+    });
+  });
 
-        test('should censor different IP formats', async () => {
-            const original = 'IP: 10.0.0.1 and 172.16.0.1';
-            const expected = 'IP: [CENSORED] and [CENSORED]';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
+  describe('IP Addresses', () => {
+    test.each([
+      ['Server IP: 192.168.1.1.', undefined, 'Server IP: [CENSORED].'],
+      ['Server IP: 192.168.1.1.', '*', 'Server IP: ***********.'],
+    ])('should censor an IP address (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
     });
 
-    describe('Vehicle Identification Numbers (VIN)', () => {
-        test('should censor a VIN', async () => {
-            const original = 'Car VIN: 1G1FN13M031234567.';
-            const expected = 'Car VIN: [CENSORED].';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
+    test.each([
+      ['IP: 10.0.0.1 and 172.16.0.1', undefined, 'IP: [CENSORED] and [CENSORED]'],
+      ['IP: 10.0.0.1 and 172.16.0.1', '*', 'IP: ******** and **********'],
+    ])('should censor different IP formats (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
+    });
+  });
 
-        test('should censor VIN with letters', async () => {
-            const original = 'VIN: ABCDEFGHIJKLMNOPQ';
-            const expected = 'VIN: [CENSORED]FGHIJKLMNOPQ';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
+  describe('Vehicle Identification Numbers (VIN)', () => {
+    test.each([
+      ['Car VIN: 1G1FN13M031234567.', undefined, 'Car VIN: [CENSORED].'],
+      ['Car VIN: 1G1FN13M031234567.', '*', 'Car VIN: *****************.'],
+    ])('should censor a VIN (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
     });
 
-    describe('Credit Card Numbers', () => {
-        test('should censor a credit card number', async () => {
-            const original = 'Card: 1234-5678-9012-3456.';
-            const expected = 'Card: [CENSORED].';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
+    test.each([
+      ['VIN: ABCDEFGHIJKLMNOPQ', undefined, 'VIN: [CENSORED]FGHIJKLMNOPQ'],
+      ['VIN: ABCDEFGHIJKLMNOPQ', '*', 'VIN: *****FGHIJKLMNOPQ'],
+    ])('should censor VIN with letters (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
+    });
+  });
 
-        test('should censor credit card with spaces', async () => {
-            const original = 'Card: 1234 5678 9012 3456';
-            const expected = 'Card: [CENSORED]';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
-
-        test('should censor a credit card expiration date with prefix', async () => {
-            const original = 'Exp: 03/26';
-            const expected = '[CENSORED]';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
-
-        test('should not censor general dates as credit card expirations without prefix', async () => {
-            const original = 'Date of birth: 01/01/1990.';
-            const expected = 'Date of birth: 01/01/1990.';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
+  describe('Credit Card Numbers', () => {
+    test.each([
+      ['Card: 1234-5678-9012-3456.', undefined, 'Card: [CENSORED].'],
+      ['Card: 1234-5678-9012-3456.', '*', 'Card: *******************.'],
+    ])('should censor a credit card number (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
     });
 
-    describe('ID Numbers', () => {
-        test('should censor a general 9-digit ID number', async () => {
-            const original = 'My ID is 987654321.';
-            const expected = 'My ID is [CENSORED]]]].';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
-
-        test('should censor a passport number', async () => {
-            const original = 'Passport: G123456789.';
-            const expected = 'Passport: [CENSORED].';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
-
-        test('should censor a medical record number (MRN)', async () => {
-            const original = 'Patient MRN-0012345.';
-            const expected = 'Patient [CENSORED]ED].';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
-
-        test('should censor a policy number', async () => {
-            const original = 'Policy: 98765.';
-            const expected = 'Policy: [CENSORED].';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
+    test.each([
+      ['Card: 1234 5678 9012 3456', undefined, 'Card: [CENSORED]'],
+      ['Card: 1234 5678 9012 3456', '*', 'Card: *******************'],
+    ])('should censor credit card with spaces (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
     });
 
-    describe('Mixed Regex PII', () => {
-        test('should handle multiple PII types in one string', async () => {
-            const original = 'John Doe (SSN: 123-45-6789) lives at 123 Oak Ave, Anytown, NY. Email: john.doe@mail.com. Phone: (555) 123-4567.';
-            const expected = '[CENSORED] (SSN: [CENSORED]) lives at 123 Oak Ave, Anytown, NY. Email: [CENSORED]. Phone: ([CENSORED].';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
-
-        test('should handle PII with different spacing in numbers', async () => {
-            const original = 'SSN: 123 45 6789 and Phone: (123)456-7890.';
-            const expected = '[CENSORED]: [CENSORED] and Phone: ([CENSORED].';
-            await expect(censorPII(original)).resolves.toBe(expected);
-        });
+    test.each([
+      ['Exp: 03/26', undefined, '[CENSORED]'],
+      ['Exp: 03/26', '*', '**********'],
+    ])('should censor a credit card expiration date with prefix (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
     });
+
+    test.each([
+      ['Date of birth: 01/01/1990.', undefined, 'Date of birth: 01/01/1990.'],
+      ['Date of birth: 01/01/1990.', '*', 'Date of birth: 01/01/1990.'],
+    ])('should not censor general dates as credit card expirations without prefix (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
+    });
+  });
+
+  describe('ID Numbers', () => {
+    test.each([
+      ['My ID is 987654321.', undefined, 'My ID is [CENSORED]]]].'],
+      ['My ID is 987654321.', '*', 'My ID is *********.'],
+    ])('should censor a general 9-digit ID number (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
+    });
+
+    test.each([
+      ['Passport: G123456789.', undefined, 'Passport: [CENSORED].'],
+      ['Passport: G123456789.', '*', 'Passport: **********.'],
+    ])('should censor a passport number (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
+    });
+
+    test.each([
+      ['Patient MRN-0012345.', undefined, 'Patient [CENSORED]ED].'],
+      ['Patient MRN-0012345.', '*', 'Patient ***********.'],
+    ])('should censor a medical record number (MRN) (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
+    });
+
+    test.each([
+      ['Policy: 98765.', undefined, 'Policy: [CENSORED].'],
+      ['Policy: 98765.', '*', 'Policy: *****.'],
+    ])('should censor a policy number (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
+    });
+  });
+
+  describe('Mixed Regex PII', () => {
+    test.each([
+      ['John Doe (SSN: 123-45-6789) lives at 123 Oak Ave, Anytown, NY. Email: john.doe@mail.com. Phone: (555) 123-4567.', undefined,
+        '[CENSORED] (SSN: [CENSORED]) lives at 123 Oak Ave, Anytown, NY. Email: [CENSORED]. Phone: ([CENSORED].'],
+      ['John Doe (SSN: 123-45-6789) lives at 123 Oak Ave, Anytown, NY. Email: john.doe@mail.com. Phone: (555) 123-4567.', '*',
+        '******** (SSN: ***********) lives at 123 Oak Ave, Anytown, NY. Email: *****************. Phone: (*************.'],
+    ])('should handle multiple PII types in one string (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
+    });
+
+    test.each([
+      ['SSN: 123 45 6789 and Phone: (123)456-7890.', undefined, '[CENSORED]: [CENSORED] and Phone: ([CENSORED].'],
+      ['SSN: 123 45 6789 and Phone: (123)456-7890.', '*', '***: *********** and Phone: (************.'],
+    ])('should handle PII with different spacing in numbers (maskChar=%s)', async (input, maskChar, expected) => {
+      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
+    });
+  });
 });

--- a/test/regex-pii.test.js
+++ b/test/regex-pii.test.js
@@ -11,164 +11,256 @@ describe('Regex PII Detection Tests', () => {
 
   describe('Social Security Number (SSN)', () => {
     test.each([
-      ['My SSN is 123-45-6789.', undefined, 'My [CENSORED] is [CENSORED].'],
-      ['My SSN is 123-45-6789.', '*', 'My *** is ***********.'],
-    ])('censors a Social Security Number (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      ['My SSN is 123-45-6789.', { maskChar: undefined }, 'My [CENSORED] is [CENSORED].'],
+      ['My SSN is 123-45-6789.', { maskChar: '*' }, 'My *** is ***********.'],
+      ['My SSN is 123-45-6789.', { maskChar: '*', maskLength: 5 }, 'My ***** is *****.'],
+    ])(
+      'censors a Social Security Number (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
 
     test.each([
-      ['SSN: 123 45 6789', undefined, '[CENSORED]: [CENSORED]'],
-      ['SSN: 123 45 6789', '*', '***: ***********'],
-    ])('censors SSN with different spacing (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      ['SSN: 123 45 6789', { maskChar: undefined }, '[CENSORED]: [CENSORED]'],
+      ['SSN: 123 45 6789', { maskChar: '*' }, '***: ***********'],
+      ['SSN: 123 45 6789', { maskChar: '*', maskLength: 5 }, '*****: *****'],
+    ])(
+      'censors SSN with different spacing (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
 
     test.each([
-      ['My number is 123-45.', undefined, 'My number is 123-45.'],
-      ['My number is 123-45.', '*', 'My number is 123-45.'],
-    ])('does not censor partial SSN-like numbers without full pattern (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      ['My number is 123-45.', { maskChar: undefined }, 'My number is 123-45.'],
+      ['My number is 123-45.', { maskChar: '*' }, 'My number is 123-45.'],
+      ['My number is 123-45.', { maskChar: '*', maskLength: 5 }, 'My number is 123-45.'],
+    ])(
+      'does not censor partial SSN-like numbers without full pattern (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
   });
 
   describe('Email Addresses', () => {
-    test('should censor an email address', async () => {
-      const original = 'Contact me at test@example.com.';
-      const expected = 'Contact me at [CENSORED].';
-      await expect(censorPII(original)).resolves.toBe(expected);
-    });
+    test.each([
+      ['Contact me at test@example.com.', { maskChar: undefined }, 'Contact me at [CENSORED].'],
+      ['Contact me at test@example.com.', { maskChar: '*' }, 'Contact me at ****************.'],
+      ['Contact me at test@example.com.', { maskChar: '*', maskLength: 5 }, 'Contact me at *****.'],
+    ])(
+      'should censor an email address (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
 
-    test('should censor email with subdomain', async () => {
-      const original = 'Email: user@sub.example.com';
-      const expected = 'Email: [CENSORED]';
-      await expect(censorPII(original)).resolves.toBe(expected);
-    });
+    test.each([
+      ['Email: user@sub.example.com', { maskChar: undefined }, 'Email: [CENSORED]'],
+      ['Email: user@sub.example.com', { maskChar: '*' }, 'Email: ********************'],
+      ['Email: user@sub.example.com', { maskChar: '*', maskLength: 5 }, 'Email: *****'],
+    ])(
+      'should censor email with subdomain (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
   });
 
   describe('Phone Numbers', () => {
     test.each([
-      ['Call me at (123) 456-7890.', undefined, 'Call me at ([CENSORED].'],
-      ['Call me at (123) 456-7890.', '*', 'Call me at (*************.'],
-    ])('censors a phone number (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      ['Call me at (123) 456-7890.', { maskChar: undefined }, 'Call me at ([CENSORED].'],
+      ['Call me at (123) 456-7890.', { maskChar: '*' }, 'Call me at (*************.'],
+      ['Call me at (123) 456-7890.', { maskChar: '*', maskLength: 5 }, 'Call me at (*****.'],
+    ])(
+      'censors a phone number (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
 
     test.each([
-      ['Phone: (123)456-7890.', undefined, '[CENSORED]: ([CENSORED].'],
-      ['Phone: (123)456-7890.', '*', '*****: (************.'],
-    ])('censors phone with different formats (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      ['Phone: (123)456-7890.', { maskChar: undefined }, '[CENSORED]: ([CENSORED].'],
+      ['Phone: (123)456-7890.', { maskChar: '*' }, '*****: (************.'],
+      ['Phone: (123)456-7890.', { maskChar: '*', maskLength: 5 }, '*****: (*****.'],
+    ])(
+      'censors phone with different formats (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
   });
 
   describe('IP Addresses', () => {
     test.each([
-      ['Server IP: 192.168.1.1.', undefined, 'Server IP: [CENSORED].'],
-      ['Server IP: 192.168.1.1.', '*', 'Server IP: ***********.'],
-    ])('should censor an IP address (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      ['Server IP: 192.168.1.1.', { maskChar: undefined }, 'Server IP: [CENSORED].'],
+      ['Server IP: 192.168.1.1.', { maskChar: '*' }, 'Server IP: ***********.'],
+      ['Server IP: 192.168.1.1.', { maskChar: '*', maskLength: 5 }, 'Server IP: *****.'],
+    ])(
+      'should censor an IP address (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
 
     test.each([
-      ['IP: 10.0.0.1 and 172.16.0.1', undefined, 'IP: [CENSORED] and [CENSORED]'],
-      ['IP: 10.0.0.1 and 172.16.0.1', '*', 'IP: ******** and **********'],
-    ])('should censor different IP formats (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      ['IP: 10.0.0.1 and 172.16.0.1', { maskChar: undefined }, 'IP: [CENSORED] and [CENSORED]'],
+      ['IP: 10.0.0.1 and 172.16.0.1', { maskChar: '*' }, 'IP: ******** and **********'],
+      ['IP: 10.0.0.1 and 172.16.0.1', { maskChar: '*', maskLength: 5 }, 'IP: ***** and *****'],
+    ])(
+      'should censor different IP formats (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
   });
 
   describe('Vehicle Identification Numbers (VIN)', () => {
     test.each([
-      ['Car VIN: 1G1FN13M031234567.', undefined, 'Car VIN: [CENSORED].'],
-      ['Car VIN: 1G1FN13M031234567.', '*', 'Car VIN: *****************.'],
-    ])('should censor a VIN (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      ['Car VIN: 1G1FN13M031234567.', { maskChar: undefined }, 'Car VIN: [CENSORED].'],
+      ['Car VIN: 1G1FN13M031234567.', { maskChar: '*' }, 'Car VIN: *****************.'],
+      ['Car VIN: 1G1FN13M031234567.', { maskChar: '*', maskLength: 5 }, 'Car VIN: *****.'],
+    ])(
+      'should censor a VIN (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
 
     test.each([
-      ['VIN: ABCDEFGHIJKLMNOPQ', undefined, 'VIN: [CENSORED]FGHIJKLMNOPQ'],
-      ['VIN: ABCDEFGHIJKLMNOPQ', '*', 'VIN: *****FGHIJKLMNOPQ'],
-    ])('should censor VIN with letters (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      ['VIN: ABCDEFGHIJKLMNOPQ', { maskChar: undefined }, 'VIN: [CENSORED]FGHIJKLMNOPQ'],
+      ['VIN: ABCDEFGHIJKLMNOPQ', { maskChar: '*' }, 'VIN: *****FGHIJKLMNOPQ'],
+      ['VIN: ABCDEFGHIJKLMNOPQ', { maskChar: '*', maskLength: 5 }, 'VIN: *****FGHIJKLMNOPQ'],
+    ])(
+      'should censor VIN with letters (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
   });
 
   describe('Credit Card Numbers', () => {
     test.each([
-      ['Card: 1234-5678-9012-3456.', undefined, 'Card: [CENSORED].'],
-      ['Card: 1234-5678-9012-3456.', '*', 'Card: *******************.'],
-    ])('should censor a credit card number (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      ['Card: 1234-5678-9012-3456.', { maskChar: undefined }, 'Card: [CENSORED].'],
+      ['Card: 1234-5678-9012-3456.', { maskChar: '*' }, 'Card: *******************.'],
+      ['Card: 1234-5678-9012-3456.', { maskChar: '*', maskLength: 5 }, 'Card: *****.'],
+    ])(
+      'should censor a credit card number (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
 
     test.each([
-      ['Card: 1234 5678 9012 3456', undefined, 'Card: [CENSORED]'],
-      ['Card: 1234 5678 9012 3456', '*', 'Card: *******************'],
-    ])('should censor credit card with spaces (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      ['Card: 1234 5678 9012 3456', { maskChar: undefined }, 'Card: [CENSORED]'],
+      ['Card: 1234 5678 9012 3456', { maskChar: '*' }, 'Card: *******************'],
+      ['Card: 1234 5678 9012 3456', { maskChar: '*', maskLength: 5 }, 'Card: *****'],
+    ])(
+      'should censor credit card with spaces (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
 
     test.each([
-      ['Exp: 03/26', undefined, '[CENSORED]'],
-      ['Exp: 03/26', '*', '**********'],
-    ])('should censor a credit card expiration date with prefix (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      ['Exp: 03/26', { maskChar: undefined }, '[CENSORED]'],
+      ['Exp: 03/26', { maskChar: '*' }, '**********'],
+      ['Exp: 03/26', { maskChar: '*', maskLength: 5 }, '*****'],
+    ])(
+      'should censor a credit card expiration date with prefix (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
 
-    test.each([
-      ['Date of birth: 01/01/1990.', undefined, 'Date of birth: 01/01/1990.'],
-      ['Date of birth: 01/01/1990.', '*', 'Date of birth: 01/01/1990.'],
-    ])('should not censor general dates as credit card expirations without prefix (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
+    describe('General Dates', () => {
+      test.each([
+        ['Date of birth: 01/01/1990.', { maskChar: undefined }, 'Date of birth: 01/01/1990.'],
+        ['Date of birth: 01/01/1990.', { maskChar: '*' }, 'Date of birth: 01/01/1990.'],
+        ['Date of birth: 01/01/1990.', { maskChar: '*', maskLength: 5 }, 'Date of birth: 01/01/1990.'],
+      ])(
+        'should not censor general dates as credit card expirations without prefix (options=%o)',
+        async (input, options, expected) => {
+          await expect(censorPII(input, options)).resolves.toBe(expected);
+        }
+      );
     });
   });
 
   describe('ID Numbers', () => {
     test.each([
-      ['My ID is 987654321.', undefined, 'My ID is [CENSORED]]]].'],
-      ['My ID is 987654321.', '*', 'My ID is *********.'],
-    ])('should censor a general 9-digit ID number (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      ['My ID is 987654321.', { maskChar: undefined }, 'My ID is [CENSORED].'],
+      ['My ID is 987654321.', { maskChar: '*' }, 'My ID is *********.'],
+      ['My ID is 987654321.', { maskChar: '*', maskLength: 5 }, 'My ID is *****.'],
+    ])(
+      'should censor a general 9-digit ID number (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
 
     test.each([
-      ['Passport: G123456789.', undefined, 'Passport: [CENSORED].'],
-      ['Passport: G123456789.', '*', 'Passport: **********.'],
-    ])('should censor a passport number (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      ['Passport: G123456789.', { maskChar: undefined }, 'Passport: [CENSORED].'],
+      ['Passport: G123456789.', { maskChar: '*' }, 'Passport: **********.'],
+      ['Passport: G123456789.', { maskChar: '*', maskLength: 5 }, 'Passport: *****.'],
+    ])(
+      'should censor a passport number (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
 
     test.each([
-      ['Patient MRN-0012345.', undefined, 'Patient [CENSORED]ED].'],
-      ['Patient MRN-0012345.', '*', 'Patient ***********.'],
-    ])('should censor a medical record number (MRN) (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      ['Patient MRN-0012345.', { maskChar: undefined }, 'Patient [CENSORED].'],
+      ['Patient MRN-0012345.', { maskChar: '*' }, 'Patient ***********.'],
+      ['Patient MRN-0012345.', { maskChar: '*', maskLength: 5 }, 'Patient *****.'],
+    ])(
+      'should censor a medical record number (MRN) (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
 
     test.each([
-      ['Policy: 98765.', undefined, 'Policy: [CENSORED].'],
-      ['Policy: 98765.', '*', 'Policy: *****.'],
-    ])('should censor a policy number (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
-    });
+      ['Policy: 98765.', { maskChar: undefined }, 'Policy: [CENSORED].'],
+      ['Policy: 98765.', { maskChar: '*' }, 'Policy: *****.'],
+      ['Policy: 98765.', { maskChar: '*', maskLength: 4 }, 'Policy: ****.'],
+    ])(
+      'should censor a policy number (options=%o)',
+      async (input, options, expected) => {
+        await expect(censorPII(input, options)).resolves.toBe(expected);
+      }
+    );
   });
 
   describe('Mixed Regex PII', () => {
     test.each([
-      ['John Doe (SSN: 123-45-6789) lives at 123 Oak Ave, Anytown, NY. Email: john.doe@mail.com. Phone: (555) 123-4567.', undefined,
-        '[CENSORED] (SSN: [CENSORED]) lives at 123 Oak Ave, Anytown, NY. Email: [CENSORED]. Phone: ([CENSORED].'],
-      ['John Doe (SSN: 123-45-6789) lives at 123 Oak Ave, Anytown, NY. Email: john.doe@mail.com. Phone: (555) 123-4567.', '*',
-        '******** (SSN: ***********) lives at 123 Oak Ave, Anytown, NY. Email: *****************. Phone: (*************.'],
-    ])('should handle multiple PII types in one string (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
+      [
+        'John Doe (SSN: 123-45-6789) lives at 123 Oak Ave, Anytown, NY. Email: john.doe@mail.com. Phone: (555) 123-4567.',
+        { maskChar: undefined },
+        '[CENSORED] (SSN: [CENSORED]) lives at 123 Oak Ave, Anytown, NY. Email: [CENSORED]. Phone: ([CENSORED].'
+      ],
+      [
+        'John Doe (SSN: 123-45-6789) lives at 123 Oak Ave, Anytown, NY. Email: john.doe@mail.com. Phone: (555) 123-4567.',
+        { maskChar: '*' },
+        '******** (SSN: ***********) lives at 123 Oak Ave, Anytown, NY. Email: *****************. Phone: (*************.'
+      ],
+      [
+        'John Doe (SSN: 123-45-6789) lives at 123 Oak Ave, Anytown, NY. Email: john.doe@mail.com. Phone: (555) 123-4567.',
+        { maskChar: '*', maskLength: 5 },
+        '***** (SSN: *****) lives at 123 Oak Ave, Anytown, NY. Email: *****. Phone: (*****.'
+      ],
+    ])('should handle multiple PII types in one string (options=%o)', async (input, options, expected) => {
+      await expect(censorPII(input, options)).resolves.toBe(expected);
     });
 
     test.each([
-      ['SSN: 123 45 6789 and Phone: (123)456-7890.', undefined, '[CENSORED]: [CENSORED] and Phone: ([CENSORED].'],
-      ['SSN: 123 45 6789 and Phone: (123)456-7890.', '*', '***: *********** and Phone: (************.'],
-    ])('should handle PII with different spacing in numbers (maskChar=%s)', async (input, maskChar, expected) => {
-      await expect(censorPII(input, { maskChar })).resolves.toBe(expected);
+      ['SSN: 123 45 6789 and Phone: (123)456-7890.', { maskChar: undefined }, '[CENSORED]: [CENSORED] and Phone: ([CENSORED].'],
+      ['SSN: 123 45 6789 and Phone: (123)456-7890.', { maskChar: '*' }, '***: *********** and Phone: (************.'],
+      ['SSN: 123 45 6789 and Phone: (123)456-7890.', { maskChar: '*', maskLength: 5 }, '*****: ***** and Phone: (*****.'],
+    ])('should handle PII with different spacing in numbers (options=%o)', async (input, options, expected) => {
+      await expect(censorPII(input, options)).resolves.toBe(expected);
     });
   });
 });

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -1,0 +1,123 @@
+/**
+ * Checks whether an entity object has valid start and end indices for text replacement.
+ *
+ * An entity is considered valid if:
+ * - `start` and `end` are numbers
+ * - `start` is greater than or equal to 0
+ * - `end` is greater than `start`
+ *
+ * @param {{ start: number, end: number }} entity The entity object containing start and end indices.
+ * @returns {boolean} `true` if the entity indices are valid, otherwise `false`.
+ */
+export function isValidEntity(entity) {
+  return (
+    typeof entity.start === 'number' &&
+    typeof entity.end === 'number' &&
+    entity.start >= 0 &&
+    entity.end > entity.start
+  );
+}
+
+/**
+ * Generates a masking string of a given length using the specified character.
+ *
+ * @param {number} length The number of times to repeat the mask character.
+ * @param {string} [maskChar] Optional single-character mask.
+ * @returns {string} A string consisting of the mask character repeated `length` times.
+ */
+export function maskSubstring(length, maskChar) {
+  if (maskChar) {
+    return maskChar.repeat(length);
+  }
+  return '[CENSORED]';
+}
+
+
+/**
+ * Checks whether a given string is a valid mask character.
+ *
+ * A valid mask character must:
+ *   1. Be a string of length 1 (Unicode grapheme-safe).
+ *   2. Be a visible character (not whitespace).
+ *   3. Not be a control character (Unicode category C).
+ *
+ * Examples of valid mask characters: '*', '#', 'X', '✓'.
+ * Examples of invalid mask characters: '', ' ', '\n', '\u0000'.
+ *
+ * @param {string} maskChar - The character to validate.
+ * @returns {boolean} True if maskChar is a single, visible, non-control character; false otherwise.
+ */
+export function isMaskCharValid(maskChar) {
+  if (typeof maskChar !== 'string') return false;
+
+  const chars = [...maskChar]; // Unicode-safe splitting
+  if (chars.length !== 1) return false;
+
+  const c = chars[0];
+  if (c.trim() === '') return false;        // No whitespace
+  if (/\p{C}/u.test(c)) return false;      // No control chars
+
+  return true;
+}
+
+/**
+ * Checks whether a given value is a valid positive integer (> 0).
+ *
+ * Conditions:
+ *   - Must be of type "number".
+ *   - Must be finite (not NaN, Infinity).
+ *   - Must be an integer (no decimals).
+ *   - Must be strictly greater than 0.
+ *   - Must be strictly lower than 8.
+ *
+ * Examples of valid: 1, 42, 999999
+ * Examples of invalid: 0, -5, 3.14, NaN, Infinity, "10", "3,14"
+ */
+export function isPositiveInteger(value) {
+  return (
+    typeof value === 'number' &&
+    Number.isFinite(value) &&
+    Number.isInteger(value) &&
+    value > 0 &&
+    value < 8
+  );
+}
+
+/**
+ * Filters out redundant entities from an array by keeping only the largest ones.
+ * 
+ * If an entity is fully contained within another entity, it will be removed.
+ * If an entity fully contains an existing entity, the smaller one is removed and replaced.
+ *
+ * @param {Array<Object>} entities - The array of entities to filter. Each entity should have:
+ *   @property {number} start - The starting index of the entity in the text.
+ *   @property {number} end - The ending index of the entity in the text.
+ *   @property {string} word - The actual text of the entity.
+ *   @property {string} entity_group - The type or category of the entity (e.g., 'SSN', 'EMAIL').
+ * @returns {Array<Object>} - A new array containing only the non-redundant, largest entities.
+ */
+export function filterRedundantEntities(entities) {
+  const entityMap = new Map(); // key: "start-end"
+
+  for (const entity of entities) {
+    let isContained = false;
+
+    for (const existing of entityMap.values()) {
+      // If current entity is fully inside an existing one
+      if (entity.start >= existing.start && entity.end <= existing.end) {
+        isContained = true;
+        break;
+      }
+      // If current entity fully contains an existing one, replace it
+      if (entity.start <= existing.start && entity.end >= existing.end) {
+        entityMap.delete(`${existing.start}-${existing.end}`);
+      }
+    }
+
+    if (!isContained) {
+      entityMap.set(`${entity.start}-${entity.end}`, entity);
+    }
+  }
+
+  return Array.from(entityMap.values());
+}


### PR DESCRIPTION
**Description:**

Extends changes introduced in [#3]
Closes/fixes [#2](https://github.com/jeeem/PII-PALADIN/issues/2)

This PR allows **PII-PALADIN** to set a `maskLength` field together with `maskChar` to obfuscate the original string character count.

---

### **Changes include:**

#### **index.js**
- Added new logic to filter out redundant entities due to some problems that originated from entities containing each other and obfuscating the same string multiple times.  
- Added a new field `maskLength` to the options object that allows configuring the custom mask to a fixed length.

#### **utils/helpers.js**
- Moved all helper logic to a new directory `utils` for better readability.

#### **tests/**
- Added tests to each of the existing cases, passing the new `maskLength` option.

---

### **Behavior:**

- `options.maskLength` only works if a `maskChar` is provided.  
  If `maskChar` is not provided but `maskLength` is, **PII-PALADIN** defaults to censored strings as `[CENSORED]`.

- With `options.maskLength`, the user can make the mask length **any value from 1 to 7** (arbitrary, may change in the future).

- If `options.maskLength` is **not provided** but `maskChar` is, **PII-PALADIN** masks PII with the same number of custom chars as the original replaced string length.

---

### **Validation rules for `options.maskLength`:**

It must:
- Be of type **number**  
- Be **finite** (not `NaN`, `Infinity`)  
- Be an **integer** (no decimals)  
- Be **strictly greater than 0**  
- Be **strictly lower than 8**

If `options.maskLength` is provided together with `maskChar` but does **not** meet these validity criteria, it defaults to `undefined` and behaves as if it was never provided.

